### PR TITLE
Added latest Guava and SLF4J versions compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ discloses issues transparently and detailed.
 
 |Issue| Severity | Affected | Patched | Impact
 |---|---|---|---|---|
-|[#205](https://github.com/games647/ChangeSkin/issues/205)|Moderate|Bungee Module after [92ed029](https://github.com/games647/ChangeSkin/commit/92ed0296e6fcbd0acf04f4f06e417403d5b22ccd) - (2.3.2+) |[ba1957a](https://github.com/games647/ChangeSkin/commit/ba1957ac5eff29652f8161c72ff60f765a97453e)| DOS (Denial-of-Service) Modified Minecraft clients could send malicious plugin messages (internal not chat). This causes an exception. Exceptions are CPU intensive if they are spammed a lot! | 
+|[#205](https://github.com/games647/ChangeSkin/issues/205)|Moderate|Bungee Module after [92ed029](https://github.com/games647/ChangeSkin/commit/92ed0296e6fcbd0acf04f4f06e417403d5b22ccd) - (2.3.2+) |[ba1957a](https://github.com/games647/ChangeSkin/commit/ba1957ac5eff29652f8161c72ff60f765a97453e)| DOS (Denial-of-Service) Modified Minecraft clients could send malicious plugin messages (internal not chat). This causes an exception. Exceptions are CPU intensive if they are spammed a lot! |
 
 If you have any questions, please open a new issue or send a private message on Spigot. Later should be also used
 for reporting in order to work on fix before publicly disclosing it.
@@ -88,7 +88,7 @@ Blacklist
 * Minecraft server software
     * Spigot 1.8.8+ or any fork of it (ex: Paper)
     * Sponge 7+
-    * BungeeCord 1.13+ (Keep in mind that BungeeCord is backwards compatible)
+    * Latest BungeeCord (Keep in mind that BungeeCord is backwards compatible)
 
 ## Network requests
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <shadedArtifactAttached>false</shadedArtifactAttached>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -29,6 +29,8 @@
                         <excludes>
                             <!--Those classes are already present in BungeeCord version-->
                             <exclude>net.md-5:bungeecord-config</exclude>
+                            <!-- Though BungeeCord ships a newer version -->
+                            <exclude>com.google.guava:guava</exclude>
                         </excludes>
                     </artifactSet>
                     <relocations>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <shadedArtifactAttached>false</shadedArtifactAttached>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-proxy</artifactId>
-            <version>1.14-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-config</artifactId>
-            <version>1.16-R0.4</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>31.0.1-jre</version>
             <scope>provided</scope>
         </dependency>
 
@@ -50,14 +50,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.0-alpha5</version>
         </dependency>
 
         <!-- snakeyaml is present in Bungee, Spigot and so we could use this independent implementation -->
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-config</artifactId>
-            <version>1.16-R0.3</version>
+            <version>1.16-R0.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,8 +35,31 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
-            <scope>provided</scope>
+            <!-- Old version that is still be used in Sponge  -->
+            <version>21.0</version>
+            <!-- Exclude compile time deps not marked as such on upstream  -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!--Database pooling-->

--- a/core/src/main/java/com/github/games647/changeskin/core/CommonUtil.java
+++ b/core/src/main/java/com/github/games647/changeskin/core/CommonUtil.java
@@ -15,7 +15,7 @@ import java.util.logging.Level;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.impl.JDK14LoggerAdapter;
+import org.slf4j.jul.JDK14LoggerAdapter;
 
 public class CommonUtil {
 

--- a/core/src/main/java/com/github/games647/changeskin/core/MojangSkinApi.java
+++ b/core/src/main/java/com/github/games647/changeskin/core/MojangSkinApi.java
@@ -64,7 +64,7 @@ public class MojangSkinApi {
         this.rateLimiter = new RateLimiter(Duration.ofMinutes(10), Math.max(rateLimit, 600));
 
         Set<Proxy> proxyBuilder = proxies.stream()
-                .map(proxy -> new InetSocketAddress(proxy.getHostText(), proxy.getPort()))
+                .map(proxy -> new InetSocketAddress(proxy.getHost(), proxy.getPort()))
                 .map(sa -> new Proxy(Type.HTTP, sa))
                 .collect(toSet());
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <shadedArtifactAttached>false</shadedArtifactAttached>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -51,6 +51,7 @@
                             <!--Those classes are already present in the Sponge version-->
                             <exclude>org.slf4j:*</exclude>
                             <exclude>com.zaxxer:HikariCP</exclude>
+                            <exclude>com.google.guava:guava</exclude>
                         </excludes>
                     </artifactSet>
                     <relocations>


### PR DESCRIPTION
(1.18+ waterfall uses older guava and slf4j versions, breaking backwards compatibility)

### Related issue
[22:49:45] [main/WARN]: Exception encountered when loading plugin: ChangeSkin
java.lang.NoSuchMethodError: 'java.lang.String com.google.common.net.HostAndPort.getHostText()'
	at com.github.games647.changeskin.core.MojangSkinApi.lambda$new$0(MojangSkinApi.java:67) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at com.github.games647.changeskin.core.MojangSkinApi.<init>(MojangSkinApi.java:69) ~[?:?]
	at com.github.games647.changeskin.core.ChangeSkinCore.load(ChangeSkinCore.java:70) ~[?:?]
	at com.github.games647.changeskin.bungee.ChangeSkinBungee.onEnable(ChangeSkinBungee.java:58) ~[?:?]
	at net.md_5.bungee.api.plugin.PluginManager.enablePlugins(PluginManager.java:315) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
	at net.md_5.bungee.BungeeCord.start(BungeeCord.java:290) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
	at net.md_5.bungee.BungeeCordLauncher.main(BungeeCordLauncher.java:67) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
	at net.md_5.bungee.Bootstrap.main(Bootstrap.java:15) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
